### PR TITLE
Fixed a href tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
             </p>
             <p class="style3"><strong>Moonlight</strong> (formerly known as Limelight) is an open source implementation of NVIDIA's GameStream protocol. We implemented the protocol used by the NVIDIA Shield and wrote a set of 3rd party clients.</p>
             <br />
-            <p class="style3"><strong>What does this mean for you?</strong> Moonlight allows you to stream your full collection of Steam games from your <a href=h ttp://shield.nvidia.com/play-pc-games/>GFE compatible PC</a> to any of your supported devices and play them. Right now, you can stream to your Android device or even another PC. Moonlight is perfect for gameplay on the go without sacrificing the graphics quality of your gaming computer.</p>
+            <p class="style3"><strong>What does this mean for you?</strong> Moonlight allows you to stream your full collection of Steam games from your <a href=http://shield.nvidia.com/play-pc-games/>GFE compatible PC</a> to any of your supported devices and play them. Right now, you can stream to your Android device or even another PC. Moonlight is perfect for gameplay on the go without sacrificing the graphics quality of your gaming computer.</p>
         </section>
     </div>
     <!-- Moonlight features tab -->


### PR DESCRIPTION
There was an extra space in the link to the GFE requirements, which prevented people from accessing the program's requirements for their computer.