### PR TITLE
Updated Discord links

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
 				<ul>
 					<li><a href="https://github.com/moonlight-stream">Github</a></li>
 					<li><a href="https://github.com/moonlight-stream/moonlight-docs/wiki/Setup-Guide">Setup Guide</a></li>
-					<li><a href="https://discord.gg/MySTSdq">Discord</a></li>
+					<li><a href="https://discord.gg/CGg5JxN">Discord</a></li>
 					<li><a href="#">Host Downloads</a>
 						<ul>
 							<li>
@@ -287,7 +287,7 @@
 				<div class="6u">
 					<section class="highlight">
 						<ul class="actions">
-							<li><a href="https://discord.gg/MySTSdq"><img src="images/discord.png" height="70" alt="Join our Discord" /></a></li>
+							<li><a href="https://discord.gg/CGg5JxN"><img src="images/discord.png" height="70" alt="Join our Discord" /></a></li>
 						</ul>
 					</section>
 				</div>
@@ -318,7 +318,7 @@
 			<br />
 			<p>Apple, the Apple logo, iPhone, and iPod touch are trademarks of Apple Inc., registered in the U.S. and other countries. App Store is a service mark of Apple Inc. Android, Google Play, and the Google Play logo are trademarks of Google Inc. GeForce, Shield, and GameStream are trademarks of NVIDIA Corporation. All other trademarks are property of their respective owners.</p>
 			<footer class="inner">
-			  <p>&copy; <span class="year">2018</span>. All rights reserved.</p>
+			  <p>&copy; <span class="year">2020</span>. All rights reserved.</p>
 			  <script type="text/javascript">
 			  var d = new Date();
 			  document.querySelector('.year').innerText = d.getFullYear();


### PR DESCRIPTION
This pull request updates the Discord invite links, as the old ones are broken. This update also bumps the default copyright year from 2018 to 2020 for people with Javascript deactivated.