### PR TITLE
fix: update links for moonlight-embedded

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,6 +103,11 @@
 								</a>
 							</li>
 							<li>
+								<a href="https://github.com/moonlight-stream/moonlight-embedded/wiki/Packages">
+									<div>Single-board computers</div>
+								</a>
+							</li>
+							<li>
 								<a href="https://apps.apple.com/us/app/moonlight-game-streaming/id1000551566">
 									<div>iOS and Apple TV</div>
 								</a>
@@ -145,11 +150,6 @@
 							<li>
 								<a href="https://github.com/mariotaku/moonlight-tv#download">
 									<div>LG webOS TV Homebrew</div>
-								</a>
-							</li>
-							<li>
-								<a href="https://github.com/irtimmer/moonlight-embedded/wiki/Packages">
-									<div>Single-board computers</div>
 								</a>
 							</li>
 						</ul>
@@ -284,10 +284,10 @@
 			<div class="row oneandhalf">
 				<div class="4u">
 					<section class="highlight">
-						<h3><a href="https://github.com/irtimmer/moonlight-embedded">Moonlight Embedded</a></h3>
-						<p>Stream to single-board computers (Community port)</p>
+						<h3><a href="https://github.com/moonlight-stream/moonlight-embedded">Moonlight Embedded</a></h3>
+						<p>Stream to single-board computers</p>
 					<ul class="actions">
-							<li><a href="https://github.com/irtimmer/moonlight-embedded/wiki/Packages" class="button style1">Download</a></li>
+							<li><a href="https://github.com/moonlight-stream/moonlight-embedded/wiki/Packages" class="button style1">Download</a></li>
 					</ul>
 					</section>
 				</div>


### PR DESCRIPTION
- Moved `moonlight-embedded` link in navbar dropdown to be with other official clients.
- Updated github urls for `moonlight-embedded`