### PR TITLE
fix: link to Sunshine instead of Nvidia Shield

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
 			</p>
 			<p class="style3"><strong>Moonlight</strong> (formerly Limelight) is an open source implementation of NVIDIA's GameStream protocol. We implemented the protocol used by the NVIDIA Shield and wrote a set of 3rd party clients.</p>
 			<br />
-			<p class="style3">You can stream your collection of PC games from your <a href="https://www.nvidia.com/en-us/shield/games/gamestream/">GameStream-compatible PC</a> to any supported device and play them remotely. Moonlight is perfect for gaming on the go without sacrificing the graphics and game selection available on PC.</p>
+			<p class="style3">You can stream your collection of PC games from your <a href="https://github.com/LizardByte/sunshine">Sunshine PC</a> to any supported device and play them remotely. Moonlight is perfect for gaming on the go without sacrificing the graphics and game selection available on PC.</p>
 		</section>
 	</div>
 	<!-- Moonlight features tab -->


### PR DESCRIPTION
It has been 1.5 years since Nvidia dropped support of GFE gamestreaming, probably time to update this.