### PR TITLE
feat: Add Moonlight for Tizen port to client downloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,6 +148,11 @@
 								</a>
 							</li>
 							<li>
+								<a href="https://github.com/brightcraft/moonlight-tizen">
+									<div>Tizen OS TV Homebrew</div>
+								</a>
+							</li>
+							<li>
 								<a href="https://github.com/moonlight-stream/moonlight-embedded/wiki/Packages">
 									<div>Single-board computers</div>
 								</a>
@@ -211,7 +216,7 @@
 						<div class="6u">
 							<section>
 								<h3 class="fas fa-mobile-alt">Multiple client platforms</h3>
-								<p>If you have an Android device, iOS device, Apple TV, PC or Mac, Chromebook, PS Vita, Nintendo Switch, Wii U, Raspberry Pi, or even a LG webOS TV, you can use <strong>Moonlight</strong> to stream games to it.</p>
+								<p>If you have an Android device, iOS device, Apple TV, PC or Mac, Chromebook, PS Vita, Nintendo Switch, Wii U, Raspberry Pi, or even a LG webOS or Tizen OS TV, you can use <strong>Moonlight</strong> to stream games to it.</p>
 							</section>
 						</div>
 					</div>
@@ -281,7 +286,7 @@
 			</div>
 			<!-- Second Row -->
 			<div class="row oneandhalf">
-				<div class="4u">
+				<div class="3u">
 					<section class="highlight">
 						<h3><a href="https://github.com/moonlight-stream/moonlight-embedded">Moonlight Embedded</a></h3>
 						<p>Stream to single-board computers</p>
@@ -290,7 +295,7 @@
 						</ul>
 					</section>
 				</div>
-				<div class="4u">
+				<div class="3u">
 					<section class="highlight">
 						<h3><a href="https://github.com/TheElixZammuto/moonlight-xbox">Moonlight for Xbox</a></h3>
 						<p>Stream to Xbox One and Xbox Series S|X Consoles (Community Port)</p>
@@ -299,12 +304,21 @@
 						</ul>
 					</section>
 				</div>
-				<div class="4u">
+				<div class="3u">
 					<section class="highlight">
 						<h3><a href="https://github.com/xyzz/vita-moonlight">Moonlight for PS Vita (Homebrew)</a></h3>
 						<p>Stream to a Homebrew-enabled PlayStation Vita (Community port)</p>
 						<ul class="actions">
 							<li><a href="https://github.com/xyzz/vita-moonlight/releases" class="button style1">Download</a></li>
+						</ul>
+					</section>
+				</div>
+				<div class="3u">
+					<section class="highlight">
+						<h3><a href="https://github.com/brightcraft/moonlight-tizen">Moonlight for Tizen OS TVs (Homebrew)</a></h3>
+						<p>Stream to a Tizen OS TV (Community port)</p>
+						<ul class="actions">
+							<li><a href="https://github.com/brightcraft/moonlight-tizen/releases" class="button style1">Download</a></li>
 						</ul>
 					</section>
 				</div>


### PR DESCRIPTION
Adds the [Moonlight for Tizen](https://github.com/brightcraft/moonlight-tizen) community port to the client downloads list on the homepage. 
This client allows users to stream games directly to their Samsung Tizen OS TVs. Since other community ports for homebrew-enabled devices such as the PS Vita (`vita-moonlight`), Nintendo Switch, and LG webOS are already prominently featured in the downloads section, it makes sense to also include the Tizen port so users can easily discover it.
### Changes made
* Added **Tizen OS TV Homebrew** to the navbar dropdown menu.
* Updated the supported devices text under the "Multiple client platforms" section to include Tizen OS TVs.
* Added a download card for the Tizen port in the second row of the Client Downloads grid (alongside the PS Vita port). The column layout was adjusted so the second row has 4 columns and the third row maintains its 3-column layout.